### PR TITLE
Migrate Chat Command Handler

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -88,8 +88,6 @@ dotnet_diagnostic.S1075.severity = none
 dotnet_diagnostic.S1118.severity = none
 # Loop should be simplified with LINQ expressions
 dotnet_diagnostic.S3267.severity = none
-# Require classes to be in a namespace
-dotnet_diagnostic.S3903.severity = none
 
 # --- IDE rules ---
 # Unnecessary usings
@@ -100,8 +98,6 @@ dotnet_diagnostic.IDE1006.severity = none
 dotnet_diagnostic.IDE0090.severity = warning
 
 # --- Code Analysis Rules ---
-# Declare types in namespaces
-dotnet_diagnostic.CA1050.severity = none
 # Ignore CultureInfo on string operations (applying locales)
 dotnet_diagnostic.CA1303.severity = none
 dotnet_diagnostic.CA1304.severity = none

--- a/JumpRoyale/src/AllPlayerData.cs
+++ b/JumpRoyale/src/AllPlayerData.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace JumpRoyale;
+
+public class AllPlayerData
+{
+    [JsonPropertyName("players")]
+    public Dictionary<string, PlayerData> Players { get; } = [];
+}

--- a/JumpRoyale/src/AllPlayerData.cs
+++ b/JumpRoyale/src/AllPlayerData.cs
@@ -6,5 +6,7 @@ namespace JumpRoyale;
 public class AllPlayerData
 {
     [JsonPropertyName("players")]
-    public Dictionary<string, PlayerData> Players { get; } = [];
+#pragma warning disable CA2227 // Collection properties should be read only
+    public Dictionary<string, PlayerData> Players { get; set; } = [];
+#pragma warning restore CA2227 // Collection properties should be read only
 }

--- a/JumpRoyale/src/ChatCommandHandler.cs
+++ b/JumpRoyale/src/ChatCommandHandler.cs
@@ -1,0 +1,5 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Godot;
+
+public class CommandHandler(string message, string senderId, string senderName, string hexColor, bool isPrivileged) { }

--- a/JumpRoyale/src/ChatCommandHandler.cs
+++ b/JumpRoyale/src/ChatCommandHandler.cs
@@ -1,5 +1,0 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-using Godot;
-
-public class CommandHandler(string message, string senderId, string senderName, string hexColor, bool isPrivileged) { }

--- a/JumpRoyale/src/Commands/ChatCommandHandler.cs
+++ b/JumpRoyale/src/Commands/ChatCommandHandler.cs
@@ -1,39 +1,25 @@
-using System.Diagnostics.CodeAnalysis;
 using Godot;
-using TwitchChat;
 using Utils;
 
 namespace JumpRoyale;
 
-public class CommandHandler
+public class CommandHandler(string message, string userId, string displayName, string colorHex, bool isPrivileged)
 {
-    public CommandHandler([NotNull] ChatMessageEventArgs args)
-    {
-        Message = args.Message;
-        DisplayName = args.DisplayName;
-        UserId = args.UserId;
-        ColorHex = args.ColorHex;
+    public string Message { get; } = message.ToLower();
 
-        ProcessMessage();
-    }
+    public string DisplayName { get; } = userId;
 
-    public string Message { get; }
+    public string UserId { get; } = displayName;
 
-    public string DisplayName { get; }
+    public string ColorHex { get; } = colorHex;
 
-    public string UserId { get; }
-
-    public string ColorHex { get; }
-
-    public bool IsPrivileged { get; }
-
-    public ChatMessageEventArgs ChatMessageEventArgs { get; } = null!;
+    public bool IsPrivileged { get; } = isPrivileged;
 
     public GenericActionHandler<object>? CallableCommand { get; }
 
     public ChatCommandParser ExecutedCommand { get; private set; } = null!;
 
-    private void ProcessMessage()
+    public void ProcessMessage()
     {
         GenericActionHandler<object>? callableCommand = TryGetCommandFromChatMessage();
 
@@ -61,7 +47,7 @@ public class CommandHandler
     /// </summary>
     public GenericActionHandler<object>? TryGetCommandFromChatMessage()
     {
-        ExecutedCommand = new(ChatMessageEventArgs.Message.ToLower());
+        ExecutedCommand = new(Message);
 
         string?[] stringArguments = ExecutedCommand.ArgumentsAsStrings();
         int?[] numericArguments = ExecutedCommand.ArgumentsAsNumbers();

--- a/JumpRoyale/src/Commands/ChatCommandHandler.cs
+++ b/JumpRoyale/src/Commands/ChatCommandHandler.cs
@@ -1,8 +1,161 @@
+using System.Diagnostics.CodeAnalysis;
+using Godot;
 using TwitchChat;
+using Utils;
 
 namespace JumpRoyale;
 
-public class CommandHandler(ChatMessageEventArgs args)
+public class CommandHandler
 {
-    public ChatMessageEventArgs ChatMessageEventArgs { get; } = args;
+    public CommandHandler([NotNull] ChatMessageEventArgs args)
+    {
+        Message = args.Message;
+        DisplayName = args.DisplayName;
+        UserId = args.UserId;
+        ColorHex = args.ColorHex;
+
+        ProcessMessage();
+    }
+
+    public string Message { get; }
+
+    public string DisplayName { get; }
+
+    public string UserId { get; }
+
+    public string ColorHex { get; }
+
+    public bool IsPrivileged { get; }
+
+    public ChatMessageEventArgs ChatMessageEventArgs { get; } = null!;
+
+    public GenericActionHandler<object>? CallableCommand { get; }
+
+    public ChatCommandParser ExecutedCommand { get; private set; } = null!;
+
+    private void ProcessMessage()
+    {
+        GenericActionHandler<object>? callableCommand = TryGetCommandFromChatMessage();
+
+        if (callableCommand is null)
+        {
+            return;
+        }
+
+        // Small workaround to call Join before other commands, because we have to let it populate the Jumpers
+        // dictionary with players
+        if (ExecutedCommand.Name.Equals("join"))
+        {
+            // Automatically dispose unused object, this is only here because we need to match the delegate, even though
+            // the jumper is not required in the Join command
+            callableCommand(new());
+        }
+
+        // Retrieve the Jumper instance and execute the command
+        // Jumper jumper = ActiveJumpers.Instance.GetById(_senderId);
+        // command(jumper);
+    }
+
+    /// <summary>
+    /// Returns a command delegate if the chat message contained a valid command name.
+    /// </summary>
+    public GenericActionHandler<object>? TryGetCommandFromChatMessage()
+    {
+        ExecutedCommand = new(ChatMessageEventArgs.Message.ToLower());
+
+        string?[] stringArguments = ExecutedCommand.ArgumentsAsStrings();
+        int?[] numericArguments = ExecutedCommand.ArgumentsAsNumbers();
+
+        // Join is the only command that can be executed by everyone, whether joined or not.
+        // All the remaining commands are only available to those who joined the game
+        if (CommandMatcher.MatchesJoin(ExecutedCommand.Name))
+        {
+            return (jumper) => HandleJoin(UserId, DisplayName, ColorHex, IsPrivileged);
+        }
+
+        // Important: when working with aliases that collide with each other, remember to use the
+        // proper order. E.g. Jump has `u` alias and if it was first on the list, it would
+        // execute if `unglow` was sent in the chat, because we don't use exact matching
+        return ExecutedCommand.Name switch
+        {
+            // -- Commands for all Chatters (active)
+            string when CommandMatcher.MatchesUnglow(ExecutedCommand.Name) => (jumper) => HandleUnglow(jumper),
+            string when CommandMatcher.MatchesJump(ExecutedCommand.Name)
+                => (jumper) => HandleJump(jumper, ExecutedCommand.Name, numericArguments[0], numericArguments[1]),
+            string when CommandMatcher.MatchesCharacterChange(ExecutedCommand.Name)
+                => (jumper) => HandleCharacterChange(jumper, numericArguments[0]),
+
+            // -- Commands for Mods, VIPs, Subs
+            string when CommandMatcher.MatchesGlow(ExecutedCommand.Name, IsPrivileged)
+                => (jumper) => HandleGlow(jumper, stringArguments[0], ColorHex),
+            string when CommandMatcher.MatchesNamecolor(ExecutedCommand.Name, IsPrivileged)
+                => (jumper) => HandleNamecolor(jumper, stringArguments[0], ColorHex),
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Changes the player's appearance by selecting a new character sprite.
+    /// </summary>
+    /// <param name="jumper">Player's Jumper object.</param>
+    /// <param name="characterChoice">Numeric choice specified in the chat message.</param>
+    private void HandleCharacterChange(object jumper, int? characterChoice)
+    {
+        GD.Print("HandleCharacterChange called");
+    }
+
+    /// <summary>
+    /// Enables the particles for the player.
+    /// </summary>
+    /// <param name="jumper">Player's Jumper object.</param>
+    /// <param name="userGlowColor">Glow color specified by the user.</param>
+    /// <param name="defaultGlowColor">Default glow color to fallback to, which is Twitch Chat color.</param>
+    private void HandleGlow(object jumper, string? userGlowColor, string defaultGlowColor)
+    {
+        GD.Print("HandleGlow called");
+    }
+
+    /// <summary>
+    /// Creates a new Jumper object for the player.
+    /// </summary>
+    /// <param name="userID">Twitch User Id.</param>
+    /// <param name="displayName">Twitch Display Name.</param>
+    /// <param name="colorHex">Twitch Chat color.</param>
+    /// <param name="isPrivileged">If this player privileged for extra features, enables them on join.</param>
+    private void HandleJoin(string userID, string displayName, string colorHex, bool isPrivileged)
+    {
+        GD.Print("HandleJoin called");
+    }
+
+    /// <summary>
+    /// Executes the Jump on player's Jumper.
+    /// </summary>
+    /// <param name="jumper">Player's Jumper object.</param>
+    /// <param name="direction">Direction alias.</param>
+    /// <param name="angle">Jump angle specified by the user (-90° - 90°) in his chat message.</param>
+    /// <param name="power">Jump power specified by the user in his chat message.</param>
+    private void HandleJump(object jumper, string direction, int? angle, int? power)
+    {
+        GD.Print("HandleJump called");
+    }
+
+    /// <summary>
+    /// Disables the particles on this player.
+    /// </summary>
+    /// <param name="jumper">Player's Jumper object.</param>
+    private void HandleUnglow(object jumper)
+    {
+        GD.Print("HandleUnglow called");
+    }
+
+    /// <summary>
+    /// Modifies the color of player's Nameplate in-game.
+    /// </summary>
+    /// <param name="jumper">Player's Jumper object.</param>
+    /// <param name="userNameColor">Name color selected by the user.</param>
+    /// <param name="defaultNameColor">Default color to fallback to, which is the Twitch Chat Color.</param>
+    private void HandleNamecolor(object jumper, string? userNameColor, string defaultNameColor)
+    {
+        GD.Print("HandleNamecolor called");
+    }
 }

--- a/JumpRoyale/src/Commands/ChatCommandHandler.cs
+++ b/JumpRoyale/src/Commands/ChatCommandHandler.cs
@@ -4,5 +4,5 @@ namespace JumpRoyale;
 
 public class CommandHandler(ChatMessageEventArgs args)
 {
-    public ChatMessageEventArgs CharMessageEventArgs { get; } = args;
+    public ChatMessageEventArgs ChatMessageEventArgs { get; } = args;
 }

--- a/JumpRoyale/src/Commands/ChatCommandHandler.cs
+++ b/JumpRoyale/src/Commands/ChatCommandHandler.cs
@@ -1,7 +1,7 @@
 using Godot;
-using Utils;
+using JumpRoyale.Utils;
 
-namespace JumpRoyale;
+namespace JumpRoyale.Commands;
 
 public class CommandHandler(string message, string userId, string displayName, string colorHex, bool isPrivileged)
 {
@@ -87,7 +87,8 @@ public class CommandHandler(string message, string userId, string displayName, s
     /// <param name="characterChoice">Numeric choice specified in the chat message.</param>
     private void HandleCharacterChange(object jumper, int? characterChoice)
     {
-        GD.Print("HandleCharacterChange called");
+        // Temporary until implemented
+        GD.Print(jumper, characterChoice);
     }
 
     /// <summary>
@@ -98,19 +99,21 @@ public class CommandHandler(string message, string userId, string displayName, s
     /// <param name="defaultGlowColor">Default glow color to fallback to, which is Twitch Chat color.</param>
     private void HandleGlow(object jumper, string? userGlowColor, string defaultGlowColor)
     {
-        GD.Print("HandleGlow called");
+        // Temporary until implemented
+        GD.Print(jumper, userGlowColor, defaultGlowColor);
     }
 
     /// <summary>
     /// Creates a new Jumper object for the player.
     /// </summary>
-    /// <param name="userID">Twitch User Id.</param>
+    /// <param name="userId">Twitch User Id.</param>
     /// <param name="displayName">Twitch Display Name.</param>
     /// <param name="colorHex">Twitch Chat color.</param>
     /// <param name="isPrivileged">If this player privileged for extra features, enables them on join.</param>
-    private void HandleJoin(string userID, string displayName, string colorHex, bool isPrivileged)
+    private void HandleJoin(string userId, string displayName, string colorHex, bool isPrivileged)
     {
-        GD.Print("HandleJoin called");
+        // Temporary until implemented
+        GD.Print(userId, displayName, colorHex, isPrivileged);
     }
 
     /// <summary>
@@ -122,7 +125,8 @@ public class CommandHandler(string message, string userId, string displayName, s
     /// <param name="power">Jump power specified by the user in his chat message.</param>
     private void HandleJump(object jumper, string direction, int? angle, int? power)
     {
-        GD.Print("HandleJump called");
+        // Temporary until implemented
+        GD.Print(jumper, direction, angle, power);
     }
 
     /// <summary>
@@ -131,7 +135,8 @@ public class CommandHandler(string message, string userId, string displayName, s
     /// <param name="jumper">Player's Jumper object.</param>
     private void HandleUnglow(object jumper)
     {
-        GD.Print("HandleUnglow called");
+        // Temporary until implemented
+        GD.Print(jumper);
     }
 
     /// <summary>
@@ -142,6 +147,7 @@ public class CommandHandler(string message, string userId, string displayName, s
     /// <param name="defaultNameColor">Default color to fallback to, which is the Twitch Chat Color.</param>
     private void HandleNamecolor(object jumper, string? userNameColor, string defaultNameColor)
     {
-        GD.Print("HandleNamecolor called");
+        // Temporary until implemented
+        GD.Print(jumper, userNameColor, defaultNameColor);
     }
 }

--- a/JumpRoyale/src/Commands/ChatCommandHandler.cs
+++ b/JumpRoyale/src/Commands/ChatCommandHandler.cs
@@ -1,0 +1,8 @@
+using TwitchChat;
+
+namespace JumpRoyale;
+
+public class CommandHandler(ChatMessageEventArgs args)
+{
+    public ChatMessageEventArgs CharMessageEventArgs { get; } = args;
+}

--- a/JumpRoyale/src/Commands/ChatCommandParser.cs
+++ b/JumpRoyale/src/Commands/ChatCommandParser.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Godot;
+using Utils;
+
+public class ChatCommandParser
+{
+    /// <summary>
+    /// Maximum amount of arguments returned by the parser. Increase, if necessary.
+    /// </summary>
+    private const int MaxArguments = 2;
+
+    private readonly List<string?> _arguments;
+
+    public ChatCommandParser(string chatMessage)
+    {
+        chatMessage ??= string.Empty;
+
+        _arguments = ParseChatMessage(chatMessage);
+
+        if (_arguments.Count > 0)
+        {
+            Name = _arguments[0] ?? string.Empty;
+
+            // We don't need the name in the arguments anymore
+            _arguments.RemoveAt(0);
+        }
+    }
+
+    public string Name { get; private set; } = string.Empty;
+
+    public string?[] ArgumentsAsStrings()
+    {
+        return [.. PadList(_arguments, null)];
+    }
+
+    /// <summary>
+    /// Tries to parse detected arguments to numbers (or nulls) and returns them in a padded
+    /// array. The padding values are nulls for easier defaulting.
+    /// </summary>
+    public int?[] ArgumentsAsNumbers()
+    {
+        List<int?> arguments = (
+            from argument in _arguments
+            let parsedArgument = ParseToNumberOrNull(argument)
+            select parsedArgument
+        ).ToList();
+
+        return [.. PadList(arguments, null)];
+    }
+
+    private static int? ParseToNumberOrNull(string test)
+    {
+        if (!int.TryParse(test, out int parsedNumber))
+        {
+            return null;
+        }
+
+        return parsedNumber;
+    }
+
+    /// <summary>
+    /// Pad the arguments so the commands can imply their own default value in case a null was
+    /// present at requested position.
+    /// </summary>
+    /// <param name="list">List to pad.</param>
+    /// <param name="padValue">"Filler" to add if the arguments count is below set Maximum.</param>
+    private static List<T> PadList<T>(List<T> list, T padValue)
+    {
+        if (list.Count < MaxArguments)
+        {
+            list.AddRange(Enumerable.Repeat(padValue, MaxArguments));
+        }
+
+        return list;
+    }
+
+    private static List<string?> ParseChatMessage(string chatMessage)
+    {
+        List<string?> result = [];
+
+        // Just hardcode the list of commands that could be using hex colors as arguments until someone finds a
+        // smarter way of doing this :)
+        string forcedMatch = chatMessage switch
+        {
+            string when chatMessage.StartsWith("glow") => "glow",
+            string when chatMessage.StartsWith("namecolor") => "namecolor",
+            _ => string.Empty,
+        };
+
+        if (!string.IsNullOrEmpty(forcedMatch))
+        {
+            return HandleColorArguments(chatMessage, forcedMatch);
+        }
+
+        string tmpWord = string.Empty;
+        bool wasDigit = false;
+        bool wasLetter = false;
+
+        // Commit from @smu4242 - this alternates between consecutive letters (as words)/digits
+        void HandleNextLetter(char? letter, bool condition, bool ifWasDigit, bool ifWasLetter)
+        {
+            if (condition)
+            {
+                result.Add(tmpWord);
+
+                tmpWord = string.Empty;
+            }
+
+            tmpWord += letter;
+            wasDigit = ifWasDigit;
+            wasLetter = ifWasLetter;
+        }
+
+        foreach (char c in chatMessage)
+        {
+            if (char.IsLetter(c))
+            {
+                HandleNextLetter(c, wasDigit, false, true);
+            }
+            else if (char.IsDigit(c) || c == '-')
+            {
+                HandleNextLetter(c, wasLetter, true, false);
+            }
+            else
+            {
+                HandleNextLetter(null, wasLetter || wasDigit, false, false);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(tmpWord))
+        {
+            result.Add(tmpWord);
+        }
+
+        if (result.Count == 0)
+        {
+            // Just a failsafe in case nothing was caught and to have reference for Name
+            result.Add(string.Empty);
+        }
+
+        return result;
+    }
+
+    private static List<string?> HandleColorArguments(string chatMessage, string splitBy)
+    {
+        // Force the supposed command name to be on the arguments list so the constructor can extract it
+        List<string?> arguments = [splitBy];
+
+        string[] split = chatMessage.Split(
+            splitBy,
+            StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
+        );
+
+        // In case there was nothing, just return to be able to default to Twitch Color (or other default)
+        if (split.Length == 0)
+        {
+            return arguments;
+        }
+
+        // If there is a split result, it can be a potential color argument, but just in case catch more than just the
+        // first argument. This will be useful if multiple color arguments are required for some commands, e.g.
+        // simple gradients or multi-colored clothes
+        string[] parameters = split[0].Split(" ");
+
+        for (int i = 0; i < Math.Min(parameters.Length, MaxArguments); i++)
+        {
+            string input = parameters[i];
+
+            // Workaround to allow "random" color later, since this fails the validation check
+            if (input.Equals("random", StringComparison.CurrentCultureIgnoreCase))
+            {
+                arguments.Add(Rng.RandomHex());
+                continue;
+            }
+
+            // If a valid Hex was provided, just add it and proceed with other arguments
+            // Note: This eliminates the need for color validity checks later
+            if (Color.HtmlIsValid(input))
+            {
+                arguments.Add(input);
+                continue;
+            }
+
+            // Finally, check if the input is usable as standardized color name
+            try
+            {
+                Color color = new(input);
+
+                arguments.Add(color.ToHtml());
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                arguments.Add(null);
+            }
+        }
+
+        return arguments;
+    }
+}

--- a/JumpRoyale/src/Commands/ChatCommandParser.cs
+++ b/JumpRoyale/src/Commands/ChatCommandParser.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Godot;
-using Utils;
+using JumpRoyale.Utils;
+
+namespace JumpRoyale.Commands;
 
 public class ChatCommandParser
 {

--- a/JumpRoyale/src/Commands/CommandMatcher.cs
+++ b/JumpRoyale/src/Commands/CommandMatcher.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
+namespace JumpRoyale.Commands;
+
 /// <summary>
 /// Provides a set of methods for pattern matching of command names extracted from a chat message.
 /// Each method accepts <c>isPrivileged</c> argument, which can eventually be used to determine if

--- a/JumpRoyale/src/Commands/CommandMatcher.cs
+++ b/JumpRoyale/src/Commands/CommandMatcher.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+/// <summary>
+/// Provides a set of methods for pattern matching of command names extracted from a chat message.
+/// Each method accepts <c>isPrivileged</c> argument, which can eventually be used to determine if
+/// the chatter can execute requested commands. True by default until specified otherwise.
+/// </summary>
+/// <remarks>
+/// The accepted <c>isPrivileged</c> checked during the command matching is only used to determine if
+/// the chatter can execute the command. This argument can also be passed to command methods
+/// in order to execute a separate part of the logic reserved for privileged users only.
+/// </remarks>
+public static class CommandMatcher
+{
+    public static readonly ImmutableList<string> CharCommandAliases = ["char"];
+    public static readonly ImmutableList<string> GlowCommandAliases = ["glow"];
+    public static readonly ImmutableList<string> JoinCommandAliases = ["join"];
+    public static readonly ImmutableList<string> JumpCommandAliases = ["j", "l", "r", "u"];
+    public static readonly ImmutableList<string> NamecolorCommandAliases = ["namecolor"];
+    public static readonly ImmutableList<string> UnglowCommandAliases = ["unglow"];
+
+    static CommandMatcher()
+    {
+        // Warning: whenever a new alias list is added, add it to this list below! It will automatically
+        // expose a list of all commands combined for display and testing purposes
+        List<ImmutableList<string>> availableAliases =
+        [
+            CharCommandAliases,
+            GlowCommandAliases,
+            JoinCommandAliases,
+            JumpCommandAliases,
+            NamecolorCommandAliases,
+            UnglowCommandAliases,
+        ];
+        List<string> allAliases = [];
+
+        foreach (ImmutableList<string> aliases in availableAliases)
+        {
+            allAliases.AddRange([.. aliases]);
+        }
+
+        AvailableCommands = [.. allAliases];
+    }
+
+    public static ImmutableList<string> AvailableCommands { get; private set; }
+
+    public static bool MatchesCharacterChange(string commandName, bool isPrivileged = true)
+    {
+        return MatchesCommandAliasPattern(CharCommandAliases, commandName, isPrivileged);
+    }
+
+    public static bool MatchesGlow(string commandName, bool isPrivileged = true)
+    {
+        return MatchesCommandAliasPattern(GlowCommandAliases, commandName, isPrivileged);
+    }
+
+    public static bool MatchesJoin(string commandName, bool isPrivileged = true)
+    {
+        return MatchesCommandAliasPattern(JoinCommandAliases, commandName, isPrivileged);
+    }
+
+    public static bool MatchesJump(string commandName, bool isPrivileged = true)
+    {
+        return MatchesCommandAliasPattern(JumpCommandAliases, commandName, isPrivileged);
+    }
+
+    public static bool MatchesNamecolor(string commandName, bool isPrivileged = true)
+    {
+        return MatchesCommandAliasPattern(NamecolorCommandAliases, commandName, isPrivileged);
+    }
+
+    public static bool MatchesUnglow(string commandName, bool isPrivileged = true)
+    {
+        return MatchesCommandAliasPattern(UnglowCommandAliases, commandName, isPrivileged);
+    }
+
+    private static bool MatchesCommandAliasPattern(
+        ImmutableList<string> aliases,
+        string commandName,
+        bool isPrivileged = true
+    )
+    {
+        return aliases.Exists(alias => commandName.StartsWith(alias)) && isPrivileged;
+    }
+}

--- a/JumpRoyale/src/Commands/JumpCommand.cs
+++ b/JumpRoyale/src/Commands/JumpCommand.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace JumpRoyale.Commands;
+
+public class JumpCommand
+{
+    private readonly List<string> _fixedAngleDirections = ["u", "ll", "lll", "jj", "rr", "jjj", "rrr"];
+
+    private int _power;
+
+    public JumpCommand([NotNull] string direction, int? angle, int? power)
+    {
+        Angle = angle ?? 0;
+        Power = power ?? 100;
+
+        // Note on [NotNull]: we already know the direction is not null, because it was caught by the CommandMatcher,
+        // so this should never happen (?) 🤔
+        AdjustAngle(direction);
+    }
+
+    /// <summary>
+    /// Gets the clamped angle from user inputs. Angle of 0 degrees points up and the angles count Clockwise.
+    /// Positive: right, negative: left.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="AdjustAngle"/> for details on external clamp of this value.
+    /// </remarks>
+    public int Angle { get; private set; }
+
+    /// <summary>
+    /// Gets the current jump power in form of "percentage" after the players can apply as an argument in the chat
+    /// message. This value is clamped between `1` and `100`.
+    /// </summary>
+    public int Power
+    {
+        get { return _power; }
+        private set { _power = Math.Clamp(value, 1, 100); }
+    }
+
+    private void AdjustAngle(string direction)
+    {
+        // There are commands, which imply in which direction we would like to jump without
+        // providing an angle. We don't want to explicitly specify an angle to jump
+        // straight up, which is inconvenient when avoiding duplicate messages
+        if (MatchesFixedAngleAlias(direction))
+        {
+            // Players may still want to specify their own Power when jumping at fixed-angle, so
+            // we can get around this by interpreting the first parameter as Power without
+            // having to specify Angle, then Power to read the second parameter
+            Power = Angle != 0 ? Angle : 100;
+        }
+
+        // Important: the reason why this value is not clamped in the property itself is that we
+        // have commands, which have implied angle and only accept Power as parameter, which
+        // we read from Angle and we can't clamp this value, otherwise we lose 10 Power
+        Angle = Math.Clamp(Angle, -90, 90);
+
+        Angle = direction switch
+        {
+            // Predefined set of angles for available jump commands. The pattern matching allows
+            // for typos and garbage while still allowing the angle to be changed.
+            string when direction.StartsWith("rrr") || direction.StartsWith("jjj") => 150,
+            string when direction.StartsWith("rr") || direction.StartsWith("jj") => 120,
+            string when direction.StartsWith("lll") => 30,
+            string when direction.StartsWith("ll") => 60,
+            string when direction.StartsWith('j') || direction.StartsWith('r') => Angle + 90,
+            string when direction.StartsWith('l') => 90 - Angle,
+            string when direction.StartsWith('u') => 90,
+            _ => 90,
+        };
+    }
+
+    private bool MatchesFixedAngleAlias(string direction)
+    {
+        return _fixedAngleDirections.Exists(alias => direction.StartsWith(alias));
+    }
+}

--- a/JumpRoyale/src/PlayerData.cs
+++ b/JumpRoyale/src/PlayerData.cs
@@ -5,53 +5,9 @@ namespace JumpRoyale;
 // Note to contributors: do not rename anything in this class without updating the corresponding JSON data on disk.
 public class PlayerData(string glowColor, int characterChoice, string nameColor)
 {
-    public int Num1stPlaceWins { get; set; }
-
-    public int Num2ndPlaceWins { get; set; }
-
-    public int Num3rdPlaceWins { get; set; }
-
-    public int NumPlays { get; set; }
-
-    public int NumJumps { get; set; }
-
-    public int TotalHeightAchieved { get; set; }
-
-    // Looks like "#RRGGBB"
-    public string GlowColor { get; set; } = glowColor;
-
     public int CharacterChoice { get; set; } = characterChoice;
 
-    /// <summary>
-    /// Current name color selected by the player. This will be used to automatically revert to default color if this
-    /// player was unprivileged or to use it again when privileged so we don't overwrite it with default color.
-    /// </summary>
-    /// <remarks>
-    /// This property is for Serialization purposes only and should not be used. If you need to return the color
-    /// selected by players only if they are privileged, use <see cref="PlayerNameColor"/>.
-    /// </remarks>
-    public string NameColor { get; private set; } = nameColor ?? "ffffff";
-
-    // Note that this can change between games since you can change your name on
-    // Twitch, so this is just for convenience of looking at the JSON file and
-    // knowing who's who.
-    public string Name { get; set; } = string.Empty;
-
-    public string UserId { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets the current name color selected by the player, but will return default color if this player was
-    /// unprivileged.
-    /// </summary>
-    /// <remarks>
-    /// This property will not be serialized.
-    /// </remarks>
-    [JsonIgnore]
-    public string PlayerNameColor
-    {
-        get => IsPrivileged ? NameColor : "ffffff";
-        set { NameColor = value; }
-    }
+    public string GlowColor { get; set; } = glowColor;
 
     /// <summary>
     /// Defines this player's current <c>isPrivileged</c> status that was set upon joining the game. This property is
@@ -67,4 +23,47 @@ public class PlayerData(string glowColor, int characterChoice, string nameColor)
     /// </summary>
     [JsonIgnore]
     public bool IsPrivileged { get; set; } = false;
+
+    // Note that this can change between games since you can change your name on
+    // Twitch, so this is just for convenience of looking at the JSON file and
+    // knowing who's who.
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Current name color selected by the player. This will be used to automatically revert to default color if this
+    /// player was unprivileged or to use it again when privileged so we don't overwrite it with default color.
+    /// </summary>
+    /// <remarks>
+    /// This property is for Serialization purposes only and should not be used. If you need to return the color
+    /// selected by players only if they are privileged, use <see cref="PlayerNameColor"/>.
+    /// </remarks>
+    public string NameColor { get; private set; } = nameColor ?? "ffffff";
+
+    public int Num1stPlaceWins { get; set; }
+
+    public int Num2ndPlaceWins { get; set; }
+
+    public int Num3rdPlaceWins { get; set; }
+
+    public int NumJumps { get; set; }
+
+    public int NumPlays { get; set; }
+
+    /// <summary>
+    /// Gets the current name color selected by the player, but will return default color if this player was
+    /// unprivileged.
+    /// </summary>
+    /// <remarks>
+    /// This property will not be serialized.
+    /// </remarks>
+    [JsonIgnore]
+    public string PlayerNameColor
+    {
+        get => IsPrivileged ? NameColor : "ffffff";
+        set { NameColor = value; }
+    }
+
+    public int TotalHeightAchieved { get; set; }
+
+    public string UserId { get; set; } = string.Empty;
 }

--- a/JumpRoyale/src/PlayerData.cs
+++ b/JumpRoyale/src/PlayerData.cs
@@ -1,0 +1,70 @@
+using System.Text.Json.Serialization;
+
+namespace JumpRoyale;
+
+// Note to contributors: do not rename anything in this class without updating the corresponding JSON data on disk.
+public class PlayerData(string glowColor, int characterChoice, string nameColor)
+{
+    public int Num1stPlaceWins { get; set; }
+
+    public int Num2ndPlaceWins { get; set; }
+
+    public int Num3rdPlaceWins { get; set; }
+
+    public int NumPlays { get; set; }
+
+    public int NumJumps { get; set; }
+
+    public int TotalHeightAchieved { get; set; }
+
+    // Looks like "#RRGGBB"
+    public string GlowColor { get; set; } = glowColor;
+
+    public int CharacterChoice { get; set; } = characterChoice;
+
+    /// <summary>
+    /// Current name color selected by the player. This will be used to automatically revert to default color if this
+    /// player was unprivileged or to use it again when privileged so we don't overwrite it with default color.
+    /// </summary>
+    /// <remarks>
+    /// This property is for Serialization purposes only and should not be used. If you need to return the color
+    /// selected by players only if they are privileged, use <see cref="PlayerNameColor"/>.
+    /// </remarks>
+    public string NameColor { get; private set; } = nameColor ?? "ffffff";
+
+    // Note that this can change between games since you can change your name on
+    // Twitch, so this is just for convenience of looking at the JSON file and
+    // knowing who's who.
+    public string Name { get; set; } = string.Empty;
+
+    public string UserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the current name color selected by the player, but will return default color if this player was
+    /// unprivileged.
+    /// </summary>
+    /// <remarks>
+    /// This property will not be serialized.
+    /// </remarks>
+    [JsonIgnore]
+    public string PlayerNameColor
+    {
+        get => IsPrivileged ? NameColor : "ffffff";
+        set { NameColor = value; }
+    }
+
+    /// <summary>
+    /// Defines this player's current <c>isPrivileged</c> status that was set upon joining the game. This property is
+    /// mostly used by Join command to instantiate the player with previously customized privileged features, but it can
+    /// also be used for commands, that are partially privileged, like extra cosmetics inside a command.
+    /// <para>
+    /// This property will not be a part of the Json data.
+    /// </para>
+    /// <para>
+    /// Example: <c>char</c> command allows to select a character from given range, but some selections could only be
+    /// applied to privileged users.
+    /// </para>
+    /// </summary>
+    [JsonIgnore]
+    public bool IsPrivileged { get; set; } = false;
+}

--- a/JumpRoyale/src/PlayerData.cs
+++ b/JumpRoyale/src/PlayerData.cs
@@ -10,6 +10,11 @@ public class PlayerData(string glowColor, int characterChoice, string nameColor)
     public string GlowColor { get; set; } = glowColor;
 
     /// <summary>
+    /// Defines the highest amount of consecutive first place game results.
+    /// </summary>
+    public int HighestWinStreak { get; set; }
+
+    /// <summary>
     /// Defines this player's current <c>isPrivileged</c> status that was set upon joining the game. This property is
     /// mostly used by Join command to instantiate the player with previously customized privileged features, but it can
     /// also be used for commands, that are partially privileged, like extra cosmetics inside a command.
@@ -63,7 +68,19 @@ public class PlayerData(string glowColor, int characterChoice, string nameColor)
         set { NameColor = value; }
     }
 
+    /// <summary>
+    /// Cumulative height from all game sessions.
+    /// </summary>
     public int TotalHeightAchieved { get; set; }
 
+    /// <summary>
+    /// User Twitch id.
+    /// </summary>
     public string UserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Defines the current win streak (1st place only). Increments every time the player achieves the first place in
+    /// the current session, resets to 0 otherwise.
+    /// </summary>
+    public int WinStreak { get; set; }
 }

--- a/JumpRoyale/src/PlayerStats.cs
+++ b/JumpRoyale/src/PlayerStats.cs
@@ -81,7 +81,7 @@ public class PlayerStats
     }
 
     /// <summary>
-    /// Returns true if the player with specified Twitch id exists in the collection
+    /// Returns true if the player with specified Twitch id exists in the collection.
     /// </summary>
     /// <param name="userId">User Twitch id.</param>
     public bool Exists(string userId)

--- a/JumpRoyale/src/PlayerStats.cs
+++ b/JumpRoyale/src/PlayerStats.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using JumpRoyale.Utils.Exceptions;
+
+namespace JumpRoyale;
+
+/// <summary>
+/// Class responsible for loading Player Data from specified Json file (serialization and deserialization).
+/// </summary>
+public class PlayerStats
+{
+    private static readonly object _lock = new();
+    private static PlayerStats? _instance;
+
+    /// <summary>
+    /// Gets currently deserialized Json data of all players.
+    /// </summary>
+    private readonly AllPlayerData _allPlayerData = new();
+
+    private PlayerStats() { }
+
+    public static PlayerStats Instance
+    {
+        get
+        {
+            lock (_lock)
+            {
+                _instance ??= new PlayerStats();
+            }
+
+            return _instance;
+        }
+    }
+
+    /// <summary>
+    /// Defines where the path for player stats is located.
+    /// </summary>
+    public string? StatsFilePath { get; set; }
+
+    /// <summary>
+    /// Clears the Players dictionary.
+    /// </summary>
+    public void ClearPlayers()
+    {
+        _allPlayerData.Players.Clear();
+    }
+
+    public bool Exists(string userId)
+    {
+        return _allPlayerData.Players.ContainsKey(userId);
+    }
+
+    /// <summary>
+    /// Returns PlayerData indexed by specified player id, if he exists in the dictionary loaded from Json file.
+    /// </summary>
+    /// <param name="playerId">Twitch User id.</param>
+    public PlayerData? GetPlayerById(string playerId)
+    {
+        _allPlayerData.Players.TryGetValue(playerId, out PlayerData? playerData);
+
+        return playerData;
+    }
+
+    /// <summary>
+    /// Attempts to read all the player data from Json file and stores it internally in <see cref="AllPlayerData"/>. If
+    /// there was no data inside (new file or empty object), returns early with state. It will only throw an exception
+    /// if the json was malformed or the structure didn't match the type.
+    /// </summary>
+    public bool LoadPlayerData()
+    {
+        ValidateStatsFilePath();
+
+        if (!File.Exists(StatsFilePath))
+        {
+            return false;
+        }
+
+        string jsonString = File.ReadAllText(StatsFilePath);
+
+        AllPlayerData? jsonResult = JsonSerializer.Deserialize<AllPlayerData>(jsonString);
+
+        if (jsonResult is null)
+        {
+            return false;
+        }
+
+        // If there was data in the json file, but we didn't get anything out of it, it probably means that main
+        // "players" property was changed, so we didn't match the required structure. Not sure what's the optimal length
+        // to test, but probably longer than: "{}". Maybe it doesn't matter here at all.
+        if (jsonResult.Players.Count == 0 && jsonString.Length > 4)
+        {
+            throw new InvalidJsonDataException();
+        }
+
+        foreach (KeyValuePair<string, PlayerData> player in jsonResult.Players)
+        {
+            _allPlayerData.Players.Add(player.Key, player.Value);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Serializes all players and stores them in the Json file.
+    /// </summary>
+    public void SaveAllPlayers()
+    {
+        string jsonString = JsonSerializer.Serialize(_allPlayerData);
+
+        ValidateStatsFilePath();
+
+        File.WriteAllText(StatsFilePath!, jsonString);
+    }
+
+    /// <summary>
+    /// Updates (or stores) the indexed player with new player data. Automatically keyed by the <c>userId</c> from
+    /// provided <c>playerData</c>.
+    /// <para>
+    /// Note: This was merged with Store, which called <c>dictionary.Add()</c>, but that requires exception handling,
+    /// but we can just directly access the index, which automatically overwrites the existing record. <c>UserId</b> is
+    /// unique anyway, so there is no way to get a duplicate unless we spawn bots with hardcoded ids.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// This only updates the dictionary entry, not the record in Json file, this is handled later during serialization.
+    /// </remarks>
+    /// <param name="playerData">New player data.</param>
+    public void UpdatePlayer(PlayerData playerData)
+    {
+        if (playerData is null)
+        {
+            throw new NullPlayerDataException();
+        }
+
+        _allPlayerData.Players[playerData.UserId] = playerData;
+    }
+
+    /// <summary>
+    /// Makes sure that <c>StatsFilePath</c> is set before being used.
+    /// </summary>
+    /// <exception cref="MissingStatsFilePathException">When <c>StatsFilePath</c> was uninitialized.</exception>
+    private void ValidateStatsFilePath()
+    {
+        if (StatsFilePath is null || StatsFilePath.Length == 0)
+        {
+            throw new MissingStatsFilePathException();
+        }
+    }
+}

--- a/JumpRoyale/src/TwitchChat/EventArgs/BitsEventArgs.cs
+++ b/JumpRoyale/src/TwitchChat/EventArgs/BitsEventArgs.cs
@@ -8,7 +8,7 @@ namespace TwitchChat;
 /// </summary>
 public class BitsEventArgs(OnBitsReceivedArgs eventArgs) : EventArgs
 {
-    public int BitsAmount { get; init; } = eventArgs.BitsUsed;
+    public int BitsAmount { get; } = eventArgs.BitsUsed;
 
-    public string UserId { get; init; } = eventArgs.UserId;
+    public string UserId { get; } = eventArgs.UserId;
 }

--- a/JumpRoyale/src/TwitchChat/EventArgs/MessageEventArgs.cs
+++ b/JumpRoyale/src/TwitchChat/EventArgs/MessageEventArgs.cs
@@ -27,13 +27,13 @@ public class ChatMessageEventArgs : EventArgs
         IsPrivileged = isPrivileged;
     }
 
-    public string Message { get; init; }
+    public string Message { get; }
 
-    public string DisplayName { get; init; }
+    public string DisplayName { get; }
 
-    public string UserId { get; init; }
+    public string UserId { get; }
 
-    public string ColorHex { get; init; }
+    public string ColorHex { get; }
 
-    public bool IsPrivileged { get; init; }
+    public bool IsPrivileged { get; }
 }

--- a/JumpRoyale/src/TwitchChat/EventArgs/MessageEventArgs.cs
+++ b/JumpRoyale/src/TwitchChat/EventArgs/MessageEventArgs.cs
@@ -1,6 +1,6 @@
 using System;
+using JumpRoyale.Utils;
 using TwitchLib.Client.Events;
-using Utils;
 
 namespace TwitchChat;
 

--- a/JumpRoyale/src/TwitchChat/EventArgs/RewardRedemptionEventArgs.cs
+++ b/JumpRoyale/src/TwitchChat/EventArgs/RewardRedemptionEventArgs.cs
@@ -17,7 +17,7 @@ public class RewardRedemptionEventArgs : EventArgs
         RedemptionId = eventArgs.RedemptionId;
     }
 
-    public string DisplayName { get; init; }
+    public string DisplayName { get; }
 
-    public Guid RedemptionId { get; init; }
+    public Guid RedemptionId { get; }
 }

--- a/JumpRoyale/src/TwitchChat/EventArgs/RewardRedemptionEventArgs.cs
+++ b/JumpRoyale/src/TwitchChat/EventArgs/RewardRedemptionEventArgs.cs
@@ -1,6 +1,6 @@
 using System;
+using JumpRoyale.Utils;
 using TwitchLib.PubSub.Events;
-using Utils;
 
 namespace TwitchChat;
 

--- a/JumpRoyale/src/TwitchChat/EventArgs/SubscriberEventArgs.cs
+++ b/JumpRoyale/src/TwitchChat/EventArgs/SubscriberEventArgs.cs
@@ -1,7 +1,7 @@
 using System;
+using JumpRoyale.Utils;
 using TwitchLib.Client.Enums;
 using TwitchLib.Client.Events;
-using Utils;
 
 namespace TwitchChat;
 

--- a/JumpRoyale/src/TwitchChat/TwitchChatClient.cs
+++ b/JumpRoyale/src/TwitchChat/TwitchChatClient.cs
@@ -58,9 +58,9 @@ public class TwitchChatClient : BaseChatClient
                 {
                     throw new InvalidOperationException("Call Initialize() before using TwitchChatClient.");
                 }
-            }
 
-            return _instance;
+                return _instance;
+            }
         }
     }
 

--- a/JumpRoyale/src/Utils/Delegates.cs
+++ b/JumpRoyale/src/Utils/Delegates.cs
@@ -1,4 +1,4 @@
-namespace Utils;
+namespace JumpRoyale.Utils;
 
 public delegate TReturnType GenericReturnActionHandler<out TReturnType>();
 

--- a/JumpRoyale/src/Utils/Delegates.cs
+++ b/JumpRoyale/src/Utils/Delegates.cs
@@ -1,0 +1,11 @@
+namespace Utils;
+
+public delegate TReturnType GenericReturnActionHandler<out TReturnType>();
+
+public delegate TReturnType GenericReturnActionHandler<out TReturnType, in TParameterType>(TParameterType param);
+
+public delegate void ActionHandler();
+
+public delegate void GenericActionHandler<in TParameterType>(TParameterType param);
+
+public delegate void GenericActionHandler<in TParameterType, in TValueType>(TParameterType param, TValueType value);

--- a/JumpRoyale/src/Utils/Exceptions/InvalidJsonDataException.cs
+++ b/JumpRoyale/src/Utils/Exceptions/InvalidJsonDataException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace JumpRoyale.Utils.Exceptions;
+
+public class InvalidJsonDataException : Exception
+{
+    public InvalidJsonDataException()
+        : base("No records returned, but the Json contains data. Make sure the deserialized type matches the file.") { }
+
+    public InvalidJsonDataException(string message)
+        : base(message) { }
+
+    public InvalidJsonDataException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/JumpRoyale/src/Utils/Exceptions/MissingPlayerDataException.cs
+++ b/JumpRoyale/src/Utils/Exceptions/MissingPlayerDataException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace JumpRoyale.Utils.Exceptions;
+
+public class NullPlayerDataException : Exception
+{
+    public NullPlayerDataException()
+        : base("You are trying to update a non-existing player. PlayerData was not provided.") { }
+
+    public NullPlayerDataException(string message)
+        : base(message) { }
+
+    public NullPlayerDataException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/JumpRoyale/src/Utils/Exceptions/MissingStatsFilePathException.cs
+++ b/JumpRoyale/src/Utils/Exceptions/MissingStatsFilePathException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace JumpRoyale.Utils.Exceptions;
+
+public class MissingStatsFilePathException : Exception
+{
+    public MissingStatsFilePathException()
+        : base("No stats file path provided. Make sure you set the path to stats file before loading players.") { }
+
+    public MissingStatsFilePathException(string message)
+        : base(message) { }
+
+    public MissingStatsFilePathException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/JumpRoyale/src/Utils/NullGuard.cs
+++ b/JumpRoyale/src/Utils/NullGuard.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Utils;
+namespace JumpRoyale.Utils;
 
 public static class NullGuard
 {
@@ -25,6 +25,25 @@ public static class NullGuard
         where TExceptionToThrow : Exception, new()
     {
         if (argument is null)
+        {
+            throw new TExceptionToThrow();
+        }
+    }
+
+    /// <summary>
+    /// Throws an exception if the provided argument is null or of 0 length. This overload should be used to validate
+    /// nullable string properties.
+    /// </summary>
+    /// <typeparam name="TExceptionToThrow">Custom exception type to throw.</typeparam>
+    public static void ThrowIfNullOrEmpty<TExceptionToThrow>([NotNull] object? argument)
+        where TExceptionToThrow : Exception, new()
+    {
+        if (argument is null)
+        {
+            throw new TExceptionToThrow();
+        }
+
+        if (argument.ToString()!.Length == 0)
         {
             throw new TExceptionToThrow();
         }

--- a/JumpRoyale/src/Utils/Rng.cs
+++ b/JumpRoyale/src/Utils/Rng.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace JumpRoyale.Utils;
+namespace Utils;
 
 public static class Rng
 {

--- a/JumpRoyale/src/Utils/Rng.cs
+++ b/JumpRoyale/src/Utils/Rng.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Utils;
+namespace JumpRoyale.Utils;
 
 public static class Rng
 {

--- a/JumpRoyale/src/Utils/StringExtensions.cs
+++ b/JumpRoyale/src/Utils/StringExtensions.cs
@@ -1,3 +1,5 @@
+namespace JumpRoyale.Utils.Extensions;
+
 public static class StringExtensions
 {
     /// <summary>

--- a/Tests/Commands/ChatCommandDetectionTests.cs
+++ b/Tests/Commands/ChatCommandDetectionTests.cs
@@ -1,7 +1,7 @@
-using JumpRoyale;
-using Utils;
+using JumpRoyale.Commands;
+using JumpRoyale.Utils;
 
-namespace Commands;
+namespace Tests.Commands;
 
 [TestFixture]
 public class ChatCommandDetectionTests

--- a/Tests/Commands/ChatCommandDetectionTests.cs
+++ b/Tests/Commands/ChatCommandDetectionTests.cs
@@ -1,0 +1,119 @@
+using JumpRoyale;
+using Utils;
+
+namespace Commands;
+
+[TestFixture]
+public class ChatCommandDetectionTests
+{
+    /// <summary>
+    /// This test checks if the available alias matchers in the CommandMatcher can interpret incoming input
+    /// as a potential command. Potential, meaning that commands are partially matched, e.g. <c>Left</c> will
+    /// still match the <c>l</c> alias, otherwise that's just unnecessary restriction.
+    /// <para>
+    /// Assumption: command matching in the game is implemented based on the string length, meaning that full
+    /// command name is matched first, then eventual alias, but ideally there should be no collision between
+    /// command names and aliases of different logic, e.g. <c>Join</c> and <c>j</c> (jump).
+    /// </para>
+    /// <para>
+    /// This means that full command name should always have the highest priority during pattern matching.
+    /// </para>
+    /// </summary>
+    [Test]
+    public void CanMatchAvailableCommands()
+    {
+        foreach (string command in CommandMatcher.AvailableCommands)
+        {
+            (string message, string commandName, bool wasMatched) = CommandNameMatcher(command);
+
+            Assert.That(
+                wasMatched,
+                Is.True,
+                $"Tried to match a command in the following chat message: {message}. Command parsed as: {commandName}. No match returned."
+            );
+        }
+    }
+
+    /// <summary>
+    /// This test makes sure that when unprivileged user tries to execute a command, it won't get matched at all
+    /// despite providing a valid alias. This is because we want to separate some commands to be available for
+    /// channel Subscribers or possibly Mods in the future.
+    /// </summary>
+    [Test]
+    public void CanRejectUnprivilegedUsers()
+    {
+        foreach (string command in new List<string>() { "glow", "namecolor" })
+        {
+            (_, string commandName, bool wasMatched) = CommandNameMatcher(command, false);
+
+            Assert.Multiple(() =>
+            {
+                // The following is probably unnecessary, but better be sure that we test the correct command
+                Assert.That(command, Does.StartWith(commandName));
+                Assert.That(wasMatched, Is.False);
+            });
+        }
+    }
+
+    /// <summary>
+    /// Note about this test, we are only watching the string part, where the chat message
+    /// starts with the command name and leave it like that, so we can still get the
+    /// player to execute the command. Glow is an exception: hex type arguments.
+    /// </summary>
+    [Test]
+    public void CanMatchTypos()
+    {
+        // Note: we allow slight typos in the chat i.e. extra character, because we wouldn't
+        // want to force the player to type again when something like "lk 30" was sent.
+        // Typo-ed Glow will ditch the argument, if no space was provided
+        List<string> commandsWithTypos =
+        [
+            "chars",
+            "char 3 3",
+            "gloww",
+            "glow uuuuu",
+            "glowf0f",
+            "glow aaa",
+            "llll 234432",
+            "joinerino",
+            "jumperoni 30 50",
+            "uwu 45",
+            "jjjj",
+            "rrrr",
+            "llll",
+            "rrl42",
+            "u u",
+            "u uu7",
+        ];
+
+        foreach (string command in commandsWithTypos)
+        {
+            (_, string commandName, bool wasMatched) = CommandNameMatcher(command, true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(command, Does.StartWith(commandName));
+                Assert.That(wasMatched, Is.True, commandName);
+            });
+        }
+    }
+
+    /// <summary>
+    /// Temporary command matcher, this roughly matches the existing pattern matcher in the <c>Arena</c> until the
+    /// logic gets separated, so it can be tested properly.
+    /// </summary>
+    /// <param name="chatMessage">Supposed chat message sent by the user.</param>
+    /// <param name="isPrivileged">Privileged state of this user privileged, allows executing the matched command when <c>true</c>.</param>
+    private Tuple<string, string, bool> CommandNameMatcher(string chatMessage, bool isPrivileged = true)
+    {
+        CommandHandler commandHandler =
+            new(chatMessage.ToLower(), string.Empty, string.Empty, string.Empty, isPrivileged);
+
+        // Returning a callable method means that out chat message managed to match appropriate command
+        GenericActionHandler<object>? command = commandHandler.TryGetCommandFromChatMessage();
+
+        return command is not null
+            ? new(chatMessage, commandHandler.ExecutedCommand.Name, true)
+            : new(chatMessage, commandHandler.ExecutedCommand.Name, false);
+    }
+}

--- a/Tests/Commands/ChatCommandHandlerTests.cs
+++ b/Tests/Commands/ChatCommandHandlerTests.cs
@@ -1,7 +1,7 @@
-using JumpRoyale;
-using Utils;
+using JumpRoyale.Commands;
+using JumpRoyale.Utils;
 
-namespace Commands;
+namespace Tests.Commands;
 
 [TestFixture]
 public class CommandHandlerTests

--- a/Tests/Commands/ChatCommandHandlerTests.cs
+++ b/Tests/Commands/ChatCommandHandlerTests.cs
@@ -1,0 +1,26 @@
+using JumpRoyale;
+using Utils;
+
+namespace Commands;
+
+[TestFixture]
+public class CommandHandlerTests
+{
+    /// <summary>
+    /// This test calls the CommandHandler directly as if it was coming from the raised event and goes through the
+    /// entire command detection scope. This will test if the sent chat message was able to get the delegate in return
+    /// for the requested command. Fails if no delegate was returned.
+    /// </summary>
+    [Test]
+    public void CanExecuteAllAvailableCommands()
+    {
+        foreach (string command in CommandMatcher.AvailableCommands)
+        {
+            CommandHandler commandHandler = new(command, "12345", "fakeUser", "ffffff", true);
+
+            GenericActionHandler<object>? matchedCommand = commandHandler.TryGetCommandFromChatMessage();
+
+            Assert.That(matchedCommand is not null && commandHandler.ExecutedCommand.Name == command);
+        }
+    }
+}

--- a/Tests/Commands/ChatCommandParserTests.cs
+++ b/Tests/Commands/ChatCommandParserTests.cs
@@ -1,0 +1,268 @@
+namespace Commands;
+
+[TestFixture]
+public class ChatCommandParserTests
+{
+    /// <summary>
+    /// This test makes sure that whatever we put in the chat message, will become a potential command.
+    /// </summary>
+    [Test]
+    public void CanExtractCommandName()
+    {
+        List<string> chatInput = ["j", "l", "u", "r", "l3", "l30 30", "r 30", "u 30 30", "rrrr7890"];
+
+        foreach (string input in chatInput)
+        {
+            ChatCommandParser command = new(input);
+
+            Assert.That(input, Does.StartWith(command.Name));
+        }
+    }
+
+    /// <summary>
+    /// This will most likely not happen on Twitch side, but in case the parser received a null or
+    /// an empty message, it should give an empty string back.
+    /// </summary>
+    [Test]
+    public void CanReturnNothingWhenEmpty()
+    {
+        List<string?> chatInput = [null, string.Empty];
+
+        foreach (string? input in chatInput)
+        {
+            // We don't care that it's possibly null here
+#pragma warning disable CS8604 // Possible null reference argument.
+            ChatCommandParser command = new(input);
+#pragma warning restore CS8604 // Possible null reference argument.
+
+            Assert.That(command.Name, Is.EqualTo(string.Empty));
+        }
+    }
+
+    /// <summary>
+    /// Not all messages are "valid", game commands ideally should be [a-zA-Z0-9-], so
+    /// as a fallback, there should be an empty string in return and sending just
+    /// a number is still a valid message interpreted as a command.
+    /// </summary>
+    [Test]
+    public void CanHandleGarbageMessage()
+    {
+        List<string> chatInput = [string.Empty, " ", ";", "!", "[]", "[#@}=]"];
+
+        foreach (string input in chatInput)
+        {
+            ChatCommandParser command = new(input);
+
+            Assert.That(command.Name, Is.EqualTo(string.Empty));
+        }
+    }
+
+    /// <summary>
+    /// This test ensures that both command formats work, where the initial space is omitted
+    /// and the argument is extracted properly (spaced and non-spaced commands).
+    /// </summary>
+    [Test]
+    public void CanExtractStringArguments()
+    {
+        List<string> commandInputs = ["l30 30", "l 30 30"];
+
+        foreach (string input in commandInputs)
+        {
+            ChatCommandParser command = new(input);
+
+            string?[] arguments = command.ArgumentsAsStrings();
+
+            foreach (string? argument in arguments)
+            {
+                Assert.That(argument, Is.EqualTo("30"));
+            }
+        }
+    }
+
+    [Test]
+    public void CanExtractNumericArguments()
+    {
+        List<string> commandInputs = ["l30 30", "l 30 30"];
+
+        foreach (string input in commandInputs)
+        {
+            ChatCommandParser command = new(input);
+
+            int?[] arguments = command.ArgumentsAsNumbers();
+
+            foreach (int? argument in arguments)
+            {
+                Assert.That(argument, Is.EqualTo(30));
+            }
+        }
+    }
+
+    /// <summary>
+    /// This test ensures that when we send just a matching command, we won't get any
+    /// extra arguments on the arguments list. This is important, because we can
+    /// later use null checks to default to something.
+    /// </summary>
+    [Test]
+    public void CanPadStringArgumentsWithNulls()
+    {
+        ChatCommandParser command = new("l");
+
+        string?[] arguments = command.ArgumentsAsStrings();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(arguments[0], Is.Null);
+            Assert.That(arguments[1], Is.Null);
+        });
+    }
+
+    [Test]
+    public void CanPadNumericArgumentsWithNulls()
+    {
+        ChatCommandParser command = new("l");
+
+        int?[] arguments = command.ArgumentsAsNumbers();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(arguments[0], Is.Null);
+            Assert.That(arguments[1], Is.Null);
+        });
+    }
+
+    /// <summary>
+    /// There are commands, which take mixed type of input, apart from numbers or simple
+    /// strings (just letters). For example, `glow` command can change the particle
+    /// color and it takes Hex input from the user, which is a mixed type.
+    /// </summary>
+    [Test]
+    public void CanExtractArgumentOfMixedType()
+    {
+        List<string> expectedOutputs = ["09B0D9", "BDFF00", "123456", "f02", "f02bc6"];
+
+        foreach (string output in expectedOutputs)
+        {
+            // Just test for both non-space and space
+            List<string> commandInputs = [$"glow {output}", $"glow{output}"];
+
+            foreach (string input in commandInputs)
+            {
+                ChatCommandParser command = new(input);
+
+                string?[] arguments = command.ArgumentsAsStrings();
+
+                Assert.That(arguments[0], Is.EqualTo(output));
+            }
+        }
+    }
+
+    [Test]
+    public void CanRejectInvalidGlowColors()
+    {
+        List<string> invalidColors = ["12342", "90 8da", "ffdd1", "v90909", "8888888", "l", "2"];
+
+        foreach (string color in invalidColors)
+        {
+            List<string> commandInputs = [$"glow {color}", $"glow{color}"];
+
+            foreach (string input in commandInputs)
+            {
+                ChatCommandParser command = new(input);
+
+                string?[] arguments = command.ArgumentsAsStrings();
+
+                Assert.That(arguments[0], Is.Null);
+            }
+        }
+    }
+
+    /// <summary>
+    /// This test makes sure that when we try to execute a multi-color command and any of the arguments is invalid,
+    /// it will be passed as null. The reason for this is to be able to set default colors in case the provided
+    /// arguments are invalid.
+    /// </summary>
+    [Test]
+    public void CanConvertInvalidColorToNull()
+    {
+        List<string> colorInputs = ["zxcv f0c", "f0c vcx"];
+
+        foreach (string color in colorInputs)
+        {
+            List<string> commandInputs = [$"glow {color}", $"glow{color}"];
+
+            foreach (string input in commandInputs)
+            {
+                ChatCommandParser command = new(input);
+
+                string?[] arguments = command.ArgumentsAsStrings();
+
+                Assert.That(arguments.ToList().Exists(argument => argument is null));
+            }
+        }
+    }
+
+    /// <summary>
+    /// This test assumes all arguments are valid colors.
+    /// </summary>
+    [Test]
+    public void CanExtractMultipleColors()
+    {
+        List<string> colorInputs = ["f0c f0c", "f0c173 434343", "919292 f0c", "f0c Ac0eAc"];
+
+        foreach (string color in colorInputs)
+        {
+            List<string> commandInputs = [$"glow {color}", $"glow{color}"];
+
+            foreach (string input in commandInputs)
+            {
+                ChatCommandParser command = new(input);
+
+                string?[] arguments = command.ArgumentsAsStrings();
+
+                Assert.That(arguments.ToList().TrueForAll(argument => argument is not null));
+            }
+        }
+    }
+
+    /// <summary>
+    /// This test makes sure that when we try to execute commands like "glow" or any other command specified by in the
+    /// CommandParser, we get a valid code name in return if there was a literal name provided by the user.
+    /// </summary>
+    [Test]
+    public void CanDetectColorNames()
+    {
+        List<string> colorInputs = ["red red", "blue f0c", "f0c green"];
+
+        foreach (string colors in colorInputs)
+        {
+            // Test for space and non-space arguments
+            List<string> commandInputs = [$"glow {colors}", $"glow{colors}"];
+
+            foreach (string input in commandInputs)
+            {
+                ChatCommandParser command = new(input);
+
+                string?[] arguments = command.ArgumentsAsStrings();
+
+                // If this evaluates to null, it means the command parser could not find the color name. The test color
+                // inside the ColorProvider was either removed or renamed (or if the CommandParser was modified),
+                // which caused the color to be returned as null, failing the name detection.
+                Assert.That(arguments.ToList().TrueForAll(argument => argument is not null), $"Command: {input}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// This test makes sure that when we pass literal "random" as namecolor argument, we don't get `null` in return as
+    /// normally garbage (as in any word) is treated as invalid color, but it should be converted into random color
+    /// beforehand.
+    /// </summary>
+    [Test]
+    public void AllowsRandomAsColorName()
+    {
+        ChatCommandParser command = new("namecolor RaNdOm");
+        string? argument = command.ArgumentsAsStrings()[0];
+
+        Assert.That(argument, Is.Not.Null);
+    }
+}

--- a/Tests/Commands/ChatCommandParserTests.cs
+++ b/Tests/Commands/ChatCommandParserTests.cs
@@ -1,4 +1,6 @@
-namespace Commands;
+using JumpRoyale.Commands;
+
+namespace Tests.Commands;
 
 [TestFixture]
 public class ChatCommandParserTests

--- a/Tests/Commands/JumpCommandTests.cs
+++ b/Tests/Commands/JumpCommandTests.cs
@@ -1,0 +1,171 @@
+using JumpRoyale.Commands;
+
+namespace Tests.Commands;
+
+[TestFixture]
+public class JumpCommandTests
+{
+    /// <summary>
+    /// This test makes sure that both non-space and spaced formats result in the same angle
+    /// and power applied to the jump.
+    /// </summary>
+    [Test]
+    public void CanOmitSpaceInJumpCommands()
+    {
+        // Reminder, Angle input of 60 to the Left evaluates to 30
+        List<string> commandInputs = ["l60 30", "l 60 30"];
+
+        foreach (string input in commandInputs)
+        {
+            (JumpCommand jump, _, _) = GetJumpFromCommand(input);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(jump.Angle, Is.EqualTo(30));
+                Assert.That(jump.Power, Is.EqualTo(30));
+            });
+        }
+    }
+
+    /// <summary>
+    /// This test makes sure that when no inputs are provided by the user, the command will use default values for
+    /// angle and power.
+    /// </summary>
+    [Test]
+    public void CanFallbackToDefaults()
+    {
+        List<string> commandInputs = ["j", "l", "r", "r r", "u"];
+
+        foreach (string input in commandInputs)
+        {
+            (JumpCommand jump, _, string commandName) = GetJumpFromCommand(input);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(jump.Angle, Is.EqualTo(90), $"Command executed: {commandName}");
+                Assert.That(jump.Power, Is.EqualTo(100), $"Command executed: {commandName}");
+            });
+        }
+    }
+
+    /// <summary>
+    /// This test makes sure that we will always jump up with any combination of parameters with <c>u</c> command.
+    /// </summary>
+    [Test]
+    public void CanAlwaysJumpUpWithAmbiguousParameters()
+    {
+        List<string> commandInputs = ["u u", "u", "u45", "u 45", "u 70 70", "u 100 90"];
+
+        foreach (string input in commandInputs)
+        {
+            (JumpCommand jump, _, string commandName) = GetJumpFromCommand(input);
+
+            Assert.That(jump.Angle, Is.EqualTo(90), $"Executed command: {commandName}");
+        }
+    }
+
+    /// <summary>
+    /// This test ensures that we can adjust the jump power of <c>u</c> command when passing just one parameter, which
+    /// normally is interpreted as <c>Angle</b> for other commands. This will also check if angle remains unchanged.
+    /// </summary>
+    [Test]
+    public void CanAdjustPowerOfJumpUp()
+    {
+        // Mind the angle conversion for the given command! "u" returns 90, because we don't convert it
+        List<string> commandInputs = ["u50", "u 50", "u50 50"];
+
+        foreach (string input in commandInputs)
+        {
+            (JumpCommand jump, _, _) = GetJumpFromCommand(input);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(jump.Angle, Is.EqualTo(90));
+                Assert.That(jump.Power, Is.EqualTo(50));
+            });
+        }
+    }
+
+    /// <summary>
+    /// Similarly to <see cref="CanAdjustPowerOfJumpUp"/>, but here we check if it still gets interpreted as UP and
+    /// we will only affect the Power.
+    /// </summary>
+    [Test]
+    public void CanAdjustPowerOfTypoedJumpUp()
+    {
+        // Mind the angle conversion for the given command! "u" returns 90, because we don't convert it
+        List<string> commandInputs = ["ughk50", "uj 50", "ufjh50 50"];
+
+        foreach (string input in commandInputs)
+        {
+            (JumpCommand jump, _, _) = GetJumpFromCommand(input);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(jump.Angle, Is.EqualTo(90));
+                Assert.That(jump.Power, Is.EqualTo(50));
+            });
+        }
+    }
+
+    /// <summary>
+    /// This test makes sure that we can still make a typo when sending a chat command and get it to parse the provided
+    /// value as Angle. Because the left side is being matched, the right side of the command can contain a typo as
+    /// long as there is no space, because the right side will then get interpreted as a parameter.
+    /// </summary>
+    [Test]
+    public void CanAdjustAngleWithTypoedCommands()
+    {
+        // "l l 5" will cause the test to fail, because the argument extractor will interpret
+        // the first string as command name and the rest will be interpreted as arguments,
+        // so the second string will default to "JUMP UP" (90 angle)
+        List<string> commands = ["lk5", "rkl-5", "la 5", "jk -5", "l 5 l", "l5 ldfs"];
+
+        foreach (string command in commands)
+        {
+            (JumpCommand jump, _, _) = GetJumpFromCommand(command);
+
+            Assert.That(jump.Angle, Is.EqualTo(85));
+        }
+    }
+
+    [Test]
+    public void ExtraJumpAliasesProduceExpectedAngleResults()
+    {
+        Dictionary<string, int> commands =
+            new()
+            {
+                { "rrr", 150 },
+                { "jjj", 150 },
+                { "rr", 120 },
+                { "jj", 120 },
+                { "lll", 30 },
+                { "ll", 60 },
+                { "u", 90 },
+            };
+
+        foreach (string command in commands.Keys)
+        {
+            (JumpCommand jump, _, _) = GetJumpFromCommand(command);
+
+            Assert.That(jump.Angle, Is.EqualTo(commands[command]));
+        }
+    }
+
+    /// <summary>
+    /// Returns the processed Jump Command from the parsed chat command. The nullable is
+    /// casted just for the sake of these tests.
+    /// </summary>
+    /// <returns>JumpCommand instance, numeric arguments from command, Command Name.</returns>
+    private Tuple<JumpCommand, int[], string> GetJumpFromCommand(string commandInput)
+    {
+        ChatCommandParser command = new(commandInput);
+
+        int?[] arguments = command.ArgumentsAsNumbers();
+
+        JumpCommand jump = new(command.Name, arguments[0], arguments[1]);
+
+        // Note: arguments are interpreted as Angle/Power values
+        return new(jump, [arguments[0] ?? 0, arguments[1] ?? 100], command.Name);
+    }
+}

--- a/Tests/Game/PlayerStatsTests.cs
+++ b/Tests/Game/PlayerStatsTests.cs
@@ -1,0 +1,265 @@
+using System.Text.Json;
+using JumpRoyale;
+using JumpRoyale.Utils.Exceptions;
+using Tests.Mocks;
+
+namespace Tests.Game;
+
+[TestFixture]
+public class PlayerStatsTests
+{
+    private readonly string _testFile = "data.json";
+
+    private PlayerData _fakePlayer;
+
+    /// <summary>
+    /// Location of the Test directory, where the data will be read from/written to.
+    /// <para>
+    /// This evaluates to: <c>absolute_path\\Tests\\bin\\Debug\\net8.0\\_TestData\\</c>.
+    /// </para>
+    /// </summary>
+    private string TestPath
+    {
+        get => $"{TestContext.CurrentContext.WorkDirectory}\\_TestData\\";
+    }
+
+    /// <summary>
+    /// Full path to the test file (path + file name).
+    /// </summary>
+    private string FullPath
+    {
+        get => TestPath + _testFile;
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        PlayerStats.Initialize(FullPath);
+        _fakePlayer = FakePlayerData.Make();
+
+        // Create the directory on fresh deploy or after project cleanup
+        if (!Directory.Exists(TestPath))
+        {
+            Directory.CreateDirectory(TestPath);
+        }
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        // Remove the stats file if it was created by any test.
+        if (File.Exists(FullPath))
+        {
+            File.Delete(FullPath);
+        }
+
+        PlayerStats.Destroy();
+    }
+
+    /// <summary>
+    /// This test checks if the player stat loading method returns false if the file does not exist. The purpose of this
+    /// test is to make sure the test cleanup is done correctly (file should not exist on start) and the condition was
+    /// not changed inside that class. We don't care if the file exists when loading or not.
+    /// </summary>
+    [Test]
+    public void DoesNotThrowWhenFileNotExists()
+    {
+        Assert.DoesNotThrow(() =>
+        {
+            PlayerStats.Instance.LoadPlayerData();
+        });
+    }
+
+    /// <summary>
+    /// Note: We only care if the path is correct during the serialization.
+    /// </summary>
+    [Test]
+    public void CanThrowIfPathWasUninitialized()
+    {
+        PlayerStats.Destroy();
+
+        Assert.Throws<MissingStatsFilePathException>(() =>
+        {
+            PlayerStats.Initialize(null!);
+        });
+        Assert.Throws<MissingStatsFilePathException>(() =>
+        {
+            PlayerStats.Initialize(string.Empty);
+        });
+    }
+
+    /// <summary>
+    /// This, in theory, should only happen when loading from some external config, so null check inside is necessary.
+    /// </summary>
+    [Test]
+    public void CanThrowWhenInitializingWithEmptyPath()
+    {
+        Assert.Throws<MissingStatsFilePathException>(() =>
+        {
+            PlayerStats.Initialize(string.Empty);
+            PlayerStats.Initialize(null!);
+        });
+    }
+
+    /// <summary>
+    /// This test makes sure that we don't throw exceptions on allowed conditions of the json data being "null" or empty
+    /// object, because the player data collection is still initialized as empty and later populated at runtime, when
+    /// serializing players.
+    /// </summary>
+    [Test]
+    public void DoesNotThrowWhenObjectIsEmptyOrNull()
+    {
+        bool state = false;
+
+        Assert.DoesNotThrow(() =>
+        {
+            // Literal "null" can't be assigned to the AllPlayerData, so this should return early with false
+            File.WriteAllText(FullPath, "null");
+
+            state = PlayerStats.Instance.LoadPlayerData();
+        });
+
+        Assert.That(state, Is.False);
+        state = false;
+
+        Assert.DoesNotThrow(() =>
+        {
+            // Having an empty object is still allowed, it just evaluates to empty collection
+            File.WriteAllText(FullPath, "{}");
+
+            state = PlayerStats.Instance.LoadPlayerData();
+        });
+
+        Assert.That(state, Is.True);
+    }
+
+    /// <summary>
+    /// This test checks if the player loading method can throw an appropriate exception when the json file contained
+    /// actual data. We only need to deliberately change the main field name, we don't care if anything is inside.
+    /// </summary>
+    [Test]
+    public void CanThrowOnMismatchedJsonStructure()
+    {
+        File.WriteAllText(FullPath, "{\"SomeStats\":{}}");
+
+        Assert.Throws<InvalidJsonDataException>(() =>
+        {
+            PlayerStats.Instance.LoadPlayerData();
+        });
+    }
+
+    [Test]
+    public void CanThrowExceptionOnMalformedJson()
+    {
+        File.WriteAllText(FullPath, "{fdf,}}");
+
+        Assert.Throws<JsonException>(() =>
+        {
+            PlayerStats.Instance.LoadPlayerData();
+        });
+    }
+
+    /// <summary>
+    /// This test makes sure that the player can be loaded properly after being saved into the file. Note: this does not
+    /// need to be deeply equal, we are only comparing the json data.
+    /// </summary>
+    [Test]
+    public void CanSerializePlayerThenDeserialize()
+    {
+        // We should start with an empty dictionary, so we will add a fake player, serialize him and then attempt to
+        // read him from the file, then make sure the same data is loaded
+        PlayerStats.Instance.UpdatePlayer(_fakePlayer);
+        PlayerStats.Instance.SaveAllPlayers();
+
+        // Start on a fresh stats instance
+        PlayerStats.Instance.ClearPlayers();
+        PlayerStats.Instance.LoadPlayerData();
+
+        PlayerData? playerFromFile = PlayerStats.Instance.GetPlayerById(_fakePlayer.UserId);
+
+        if (playerFromFile is null)
+        {
+            Assert.Fail();
+        }
+
+        string fakeSerialized = JsonSerializer.Serialize(_fakePlayer);
+        string playerFromFileSerialized = JsonSerializer.Serialize(playerFromFile);
+
+        Assert.That(fakeSerialized, Is.EqualTo(playerFromFileSerialized));
+    }
+
+    /// <summary>
+    /// This test just makes sure that we return the player we just saved through implemented methods.
+    /// </summary>
+    [Test]
+    public void CanSetAndGetPlayerById()
+    {
+        string id = _fakePlayer.UserId;
+
+        // Kind of simulate that we save the players, then in the next session we load them and at some point we have to
+        // take the specific player.
+        PlayerStats.Instance.UpdatePlayer(_fakePlayer);
+        PlayerStats.Instance.SaveAllPlayers();
+
+        // Clear the dictionary to make sure the players are being loaded correctly.
+        PlayerStats.Instance.ClearPlayers();
+        PlayerStats.Instance.LoadPlayerData();
+
+        PlayerData? player = PlayerStats.Instance.GetPlayerById(id);
+
+        Assert.That(player?.UserId, Is.EqualTo(id));
+    }
+
+    /// <summary>
+    /// This test just makes sure the method returns null. The purpose of a nullable return is to inform that we
+    /// probably did something wrong when loading or inserting new players.
+    /// </summary>
+    [Test]
+    public void CanReturnNullIfNoPlayerWasFound()
+    {
+        PlayerData? player = PlayerStats.Instance.GetPlayerById("????");
+
+        Assert.That(player, Is.Null);
+    }
+
+    /// <summary>
+    /// This test makes sure that we can correctly replace the player data under user id from that data.
+    /// </summary>
+    [Test]
+    public void CanUpdatePlayers()
+    {
+        PlayerStats.Instance.UpdatePlayer(_fakePlayer);
+
+        _fakePlayer.Name = "NewName";
+
+        PlayerStats.Instance.UpdatePlayer(_fakePlayer);
+
+        PlayerData? player = PlayerStats.Instance.GetPlayerById(_fakePlayer.UserId);
+
+        Assert.That(player?.Name, Is.EqualTo("NewName"));
+    }
+
+    /// <summary>
+    /// Just a sanity check.
+    /// </summary>
+    [Test]
+    public void CanThrowWhenUpdatingFromNullData()
+    {
+        Assert.Throws<NullPlayerDataException>(() =>
+        {
+            PlayerStats.Instance.UpdatePlayer(null!);
+        });
+    }
+
+    [Test]
+    public void TestsPlayerExistenceChecks()
+    {
+        PlayerStats.Instance.UpdatePlayer(_fakePlayer);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(PlayerStats.Instance.Exists(_fakePlayer.UserId), Is.True);
+            Assert.That(PlayerStats.Instance.Exists("nonexistentuserid"), Is.False);
+        });
+    }
+}

--- a/Tests/Mocks/FakePlayerData.cs
+++ b/Tests/Mocks/FakePlayerData.cs
@@ -16,6 +16,8 @@ public static class FakePlayerData
                 Num3rdPlaceWins = Rng.RandomInt(),
                 NumJumps = Rng.RandomInt(),
                 NumPlays = Rng.RandomInt(),
+                HighestWinStreak = Rng.RandomInt(),
+                WinStreak = Rng.RandomInt(),
                 Name = Path.GetRandomFileName(), /* looks like: "zewrsrzg.rfp" */
             };
 

--- a/Tests/Mocks/FakePlayerData.cs
+++ b/Tests/Mocks/FakePlayerData.cs
@@ -1,0 +1,24 @@
+using JumpRoyale;
+using JumpRoyale.Utils;
+
+namespace Tests.Mocks;
+
+public static class FakePlayerData
+{
+    public static PlayerData Make()
+    {
+        PlayerData fakePlayer =
+            new(Rng.RandomHex(), Rng.RandomInt(), Rng.RandomHex())
+            {
+                UserId = Rng.RandomInt().ToString(),
+                Num1stPlaceWins = Rng.RandomInt(),
+                Num2ndPlaceWins = Rng.RandomInt(),
+                Num3rdPlaceWins = Rng.RandomInt(),
+                NumJumps = Rng.RandomInt(),
+                NumPlays = Rng.RandomInt(),
+                Name = Path.GetRandomFileName(), /* looks like: "zewrsrzg.rfp" */
+            };
+
+        return fakePlayer;
+    }
+}

--- a/Tests/Twitch/BaseTwitchTests.cs
+++ b/Tests/Twitch/BaseTwitchTests.cs
@@ -1,7 +1,7 @@
 using Tests.Mocks;
 using TwitchChat;
 
-namespace Twitch.Tests;
+namespace Tests.Twitch;
 
 public class BaseTwitchTests
 {

--- a/Tests/Twitch/FakeTwitchEventTests.cs
+++ b/Tests/Twitch/FakeTwitchEventTests.cs
@@ -1,4 +1,3 @@
-using Twitch.Tests;
 using TwitchChat;
 using TwitchChat.Extensions;
 using TwitchLib.Client.Enums;

--- a/Tests/Twitch/TwitchChatClientTests.cs
+++ b/Tests/Twitch/TwitchChatClientTests.cs
@@ -1,4 +1,3 @@
-using Twitch.Tests;
 using TwitchChat;
 using TwitchChat.Exceptions;
 

--- a/Tests/Utils/NullGuardTests.cs
+++ b/Tests/Utils/NullGuardTests.cs
@@ -1,0 +1,60 @@
+using System.Data;
+using JumpRoyale.Utils;
+
+namespace Tests.Utils;
+
+[TestFixture]
+public class NullGuardTests
+{
+    /// <summary>
+    /// This test checks the overload without generic parameter, which should throw ArgumentNullException.
+    /// </summary>
+    [Test]
+    public void TestsDefaultGuard()
+    {
+        object? test = null;
+
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            NullGuard.ThrowIfNull(test);
+        });
+    }
+
+    /// <summary>
+    /// This test checks the overload with specific parameter, which should throw the specified exception type.
+    /// </summary>
+    [Test]
+    public void TestsTypeSpecificGuard()
+    {
+        object? test = null;
+
+        Assert.Throws<SyntaxErrorException>(() =>
+        {
+            NullGuard.ThrowIfNull<SyntaxErrorException>(test);
+        });
+    }
+
+    /// <summary>
+    /// This test checks the overload with nullable parameter for strings, which should throw custom exception both if
+    /// the argument was null or empty.
+    /// </summary>
+    [Test]
+    public void TestsNullOrEmptyGuard()
+    {
+        string? test = null;
+
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            NullGuard.ThrowIfNullOrEmpty<ArgumentNullException>(test);
+        });
+
+        // Empty string should also throw with this guard, because we sometimes need to force initialization of a
+        // property, which is used e.g. for file paths.
+        test = string.Empty;
+
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            NullGuard.ThrowIfNullOrEmpty<ArgumentNullException>(test);
+        });
+    }
+}

--- a/Tests/Utils/NullGuardTests.cs
+++ b/Tests/Utils/NullGuardTests.cs
@@ -35,8 +35,8 @@ public class NullGuardTests
     }
 
     /// <summary>
-    /// This test checks the overload with nullable parameter for strings, which should throw custom exception both if
-    /// the argument was null or empty.
+    /// This test checks the overload with nullable parameter for strings, which should throw custom exception if the
+    /// argument was null or empty.
     /// </summary>
     [Test]
     public void TestsNullOrEmptyGuard()


### PR DESCRIPTION
This PR merges the old command-related tests, and implements some adjustments (`PlayerStats` has a proper singleton initialization).

Until `Jumper` class is implemented, the `CommandHandler` uses `object` as a temporary replacement.